### PR TITLE
[IMO] ページのアクセシビリティ補強対応

### DIFF
--- a/src/components/Judge/Result.tsx
+++ b/src/components/Judge/Result.tsx
@@ -60,7 +60,7 @@ export const Result: VFC<Props> = ({
   return (
     <Card>
       {heading}
-      <div role="img" aria-label={`星 5 つ中 ${integerScore} つ`}>
+      <div role="img" aria-label={`星 5 点満点中で ${integerScore} 点`}>
         <span aria-hidden="true">{renderStar(integerScore)}</span>
       </div>
     </Card>

--- a/src/components/Judge/Result.tsx
+++ b/src/components/Judge/Result.tsx
@@ -29,7 +29,7 @@ export const Result: VFC<Props> = ({
 
   const showScore = isDajare || isForcedShowScore;
 
-  const heading = <h1 className="font-bold mb-2">判定結果</h1>;
+  const heading = <h2 className="font-bold mb-2">判定結果</h2>;
 
   if (isDajare === undefined) {
     return loading;

--- a/src/components/Judge/Share.tsx
+++ b/src/components/Judge/Share.tsx
@@ -25,6 +25,7 @@ export const Share: VFC<Props> = ({ dajare, isDajare, integerScore }) => {
         hashtags={['ダジャレ判定']}
         className="px-4 py-2 bg-twitter text-white rounded-sm"
         resetButtonStyle={false}
+        aria-label="結果をツイート"
       >
         結果をツイート
       </TwitterShareButton>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,9 @@ const IndexPage: NextPage = () => (
       path="/"
     />
     <header className="max-w-2xl mx-auto">
-      <Hero />
+      <h1>
+        <Hero />
+      </h1>
     </header>
     <Layout hasHeader={false} fullHeight={false}>
       <section>

--- a/src/pages/judge.tsx
+++ b/src/pages/judge.tsx
@@ -45,6 +45,9 @@ const JudgePage: VFC = () => {
 
       <div className="flex flex-col gap-6">
         <form className="flex gap-4" onSubmit={handleSubmit}>
+          <label htmlFor="input-dajare" className="sr-only">
+            ダジャレ入力欄
+          </label>
           <input
             type="text"
             name="dajare"

--- a/src/pages/judge.tsx
+++ b/src/pages/judge.tsx
@@ -41,7 +41,7 @@ const JudgePage: VFC = () => {
         description="ダジャレスコアを判定します"
         path="/judge"
       />
-      <Heading>ダジャレ判定</Heading>
+      <Heading headingLevel="h1">ダジャレ判定</Heading>
 
       <div className="flex flex-col gap-6">
         <form className="flex gap-4" onSubmit={handleSubmit}>


### PR DESCRIPTION
こんにちは。本日開催されていた[焼肉争奪戦！NU CAMP Dev&Pub LT Party](https://ntsa.connpass.com/event/211862/) を観覧枠で聴いていたものです。
星の点数読み上げ対応をされていると聴いたときは、素晴らしい対応だなと思いました。

ソースコードの方拝見させていただいて、アクセシビリティ観点での補強として出させて頂きました。
完全に IMO （個人的な意見）なプルリクエストになりますが、もしよければ見ていただければと思います 🙏🏼 